### PR TITLE
Added possibility to give user acces to all commands

### DIFF
--- a/net/Animes4Me/Spigot/Plugin.java
+++ b/net/Animes4Me/Spigot/Plugin.java
@@ -78,7 +78,8 @@ import com.pengrad.telegrambot.model.Update;
 		public void recieve(Update update) {
 			if(update.message().text().startsWith("/")){
 				String cmd = update.message().text().substring(1, update.message().text().length()).split(" ")[0].toLowerCase();
-				if(config.getString("permissions." + update.message().from().username() + "." + cmd) != null){
+				if(config.getString(config.getString("permissions." + update.message().from().username() + ".*" ) != null || 
+						"permissions." + update.message().from().username() + "." + cmd) != null ){
 					boolean result = getServer().dispatchCommand(getServer().getConsoleSender(), update.message().text().substring(1, update.message().text().length()));
 					if(result){
 						telegram.send(config.getString("messages.cmd_success").replace("<CMD>", update.message().text()));


### PR DESCRIPTION
It could be a tedious job to add all the allowed permissions to the
config.yml file.

This line of code adds the ability to give a single user (or multiple)
acces to all command. Therefor is must be used with caution and only be
given to e.g. a server owner or a well trusted admin.

Usage in config.yml:

```
permissions:
  WouterJanson:
    *: true
```
